### PR TITLE
Implement Pharma Price Parser

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,97 @@
+import os
+import sys
+from dataclasses import dataclass
+from typing import List, Dict
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+from langchain.chat_models import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate
+from langchain.output_parsers import PydanticOutputParser
+from pydantic import BaseModel, Field
+from langchain_experimental.tools import PythonAstREPLTool
+from langchain.memory import ConversationBufferMemory
+from langchain.agents import create_openai_tools_agent, AgentExecutor
+
+__all__ = ["ingest_prices", "ask_insights"]
+
+# Pydantic model for structured output
+class Product(BaseModel):
+    sku: str = Field(..., description="product name")
+    manufacturer: str = Field(..., description="manufacturer name")
+    price: float = Field(..., description="price as float")
+
+# Output parser for the LLM
+_product_parser = PydanticOutputParser(pydantic_object=Product)
+
+# Prompt template for ingestion agent
+_ingest_prompt = ChatPromptTemplate.from_template(
+    """Ты — эксперт-фармацевт и веб-скрейпер.
+Проанализируй HTML-контент страницы и верни данные.
+{format_instructions}
+<HTML>{html_text}</HTML>
+Только JSON, без комментариев."""
+).partial(format_instructions=_product_parser.get_format_instructions())
+
+# LLM used for both agents
+def _get_llm(temp: float) -> ChatOpenAI:
+    return ChatOpenAI(model_name="gpt-4o-mini", temperature=temp)
+
+
+def _fetch_html(url: str) -> str:
+    """Download and sanitize page content."""
+    proxy = os.getenv("PROXY")
+    proxies = {"http": proxy, "https": proxy} if proxy else None
+    resp = requests.get(url, timeout=15, proxies=proxies)
+    resp.raise_for_status()
+    return BeautifulSoup(resp.text, "lxml").get_text(" ", strip=True)
+
+
+def _parse_product(html_text: str) -> Product:
+    """Call LLM to parse product info from HTML text."""
+    llm = _get_llm(0.0)
+    chain = _ingest_prompt | llm | _product_parser
+    return chain.invoke({"html_text": html_text})
+
+
+def ingest_prices(csv_path: str) -> pd.DataFrame:
+    """Read URLs, scrape pages and return dataframe."""
+    urls = pd.read_csv(csv_path)["urls"].dropna()
+    records: List[Dict] = []
+    for url in urls:
+        try:
+            text = _fetch_html(url)
+            product = _parse_product(text)
+            records.append(product.dict())
+        except Exception as exc:  # noqa: BLE001
+            print(f"Failed to process {url}: {exc}", file=sys.stderr)
+    df = pd.DataFrame(records, columns=["sku", "manufacturer", "price"])
+    tmp = "prices.parquet.tmp"
+    df.to_parquet(tmp, index=False)
+    os.replace(tmp, "prices.parquet")
+    return df
+
+
+def ask_insights(df: pd.DataFrame, question: str) -> str:
+    """Answer analytical question about dataframe."""
+    llm = _get_llm(0.2)
+    tool = PythonAstREPLTool(locals={"df": df})
+    tools = [tool]
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "Ты — фармацевт-аналитик данных. "
+                "Тебе доступен объект pandas DataFrame `df` со столбцами sku, manufacturer, price. "
+                "Отвечай на вопрос пользователя, применяя код Python внутри текстовых блоков ```python ... ```. "
+                "Если код что-то выводит (таблицу или график), покажи результат пользователю. "
+                "В конце — краткий вывод.",
+            ),
+            ("human", "Вопрос: {question}"),
+        ]
+    )
+    agent = create_openai_tools_agent(llm=llm, tools=tools, prompt=prompt)
+    memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+    executor = AgentExecutor(agent=agent, tools=tools, memory=memory)
+    return executor.invoke({"question": question})["output"]

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,0 +1,13 @@
+from agents import ingest_prices, ask_insights
+import argparse
+
+parser = argparse.ArgumentParser(description="Pharma price pipeline")
+parser.add_argument("--csv", required=True, help="CSV file with urls column")
+parser.add_argument("--question", required=True, help="Question for insights agent")
+args = parser.parse_args()
+
+if __name__ == "__main__":
+    df = ingest_prices(args.csv)
+    print(df.head())
+    answer = ask_insights(df, args.question)
+    print(answer)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from unittest import mock
+import agents
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def test_ingest_prices(tmp_path):
+    csv = tmp_path / "urls.csv"
+    csv.write_text("urls\nhttp://example.com\n")
+
+    html = "<html><body>Ibuprofen ACME 100</body></html>"
+    with mock.patch("agents.requests.get", return_value=DummyResponse(html)):
+        with mock.patch("agents._parse_product") as mock_parse:
+            mock_parse.return_value = agents.Product(sku="Ibu", manufacturer="ACME", price=100.0)
+            df = agents.ingest_prices(str(csv))
+
+    assert list(df.columns) == ["sku", "manufacturer", "price"]
+    assert df.iloc[0]["sku"] == "Ibu"
+
+
+def test_ask_insights():
+    df = pd.DataFrame({"sku": ["A"], "manufacturer": ["B"], "price": [1.0]})
+    class DummyExec:
+        def __init__(self, *_, **__):
+            pass
+
+        def invoke(self, *_args, **_kwargs):
+            return {"output": "ok"}
+
+    with mock.patch("agents.AgentExecutor", DummyExec):
+        with mock.patch("agents.create_openai_tools_agent"):
+            with mock.patch("agents._get_llm"):
+                result = agents.ask_insights(df, "question")
+    assert result == "ok"


### PR DESCRIPTION
## Summary
- add ingest and insights agents
- expose run_pipeline script for CLI usage
- test agent behavior with mocked LLM and requests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f7d325d08324a09c218c457c5ae3