### PR TITLE
Fix unauthorized errors by adding user-agent

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -45,7 +45,8 @@ def _fetch_html(url: str) -> str:
     """Download and sanitize page content."""
     proxy = os.getenv("PROXY")
     proxies = {"http": proxy, "https": proxy} if proxy else None
-    resp = requests.get(url, timeout=15, proxies=proxies)
+    headers = {"User-Agent": "Mozilla/5.0"}
+    resp = requests.get(url, timeout=15, proxies=proxies, headers=headers)
     resp.raise_for_status()
     return BeautifulSoup(resp.text, "lxml").get_text(" ", strip=True)
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -39,3 +39,11 @@ def test_ask_insights():
             with mock.patch("agents._get_llm"):
                 result = agents.ask_insights(df, "question")
     assert result == "ok"
+
+
+def test_fetch_html_uses_user_agent():
+    resp = DummyResponse("<html></html>")
+    with mock.patch("agents.requests.get", return_value=resp) as mock_get:
+        agents._fetch_html("http://example.com")
+        headers = mock_get.call_args.kwargs.get("headers", {})
+        assert "User-Agent" in headers


### PR DESCRIPTION
## Summary
- send a browser-like user agent header when fetching HTML
- test that `_fetch_html` includes the header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590cfb7140832493607d1d599a815c